### PR TITLE
Relative path & unicode fixes for data split script

### DIFF
--- a/scripts/prepare_dataset.sh
+++ b/scripts/prepare_dataset.sh
@@ -18,10 +18,11 @@ mv duplicate_files.txt ManyTypes4Py/duplicate_files.txt
 
 # 4. Make copy of dataset without duplicates
 mv $1 repos_
-python3 process_dataset.py repos_ ManyTypes4Py/duplicate_files.txt ManyTypes4Py/repos
+python3 process_dataset.py repos_ ManyTypes4Py/duplicate_files.txt repos
 
 # 5. Split dataset files into train, test, validate
-python3 split_dataset.py ManyTypes4Py/repos --od ManyTypes4Py/dataset_split.csv
+python3 split_dataset.py repos --od ManyTypes4Py/dataset_split.csv
+mv repos ManyTypes4Py/repos
 
 # 6. Zip contents
 tar -czvf dataset.tar.gz ManyTypes4Py

--- a/scripts/split_dataset.py
+++ b/scripts/split_dataset.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser
 from sklearn.model_selection import train_test_split
 import os
 import pandas as pd
+import sys
 
 def list_files(directory: str) -> list:
     """
@@ -71,5 +72,7 @@ if __name__ == "__main__":
     print("Combining train, test & validation into dataframe")
     result_df = pd.concat([df_train, df_test, df_valid])
 
+    # https://stackoverflow.com/questions/36303919/python-3-0-open-default-encoding
+    # https://stackoverflow.com/questions/1052225/convert-python-filenames-to-unicode
     print("Writing dataframe to:", OUTPUT_PATH)
-    result_df.to_csv(OUTPUT_PATH, header=False, index=False)
+    result_df.to_csv(OUTPUT_PATH, header=False, index=False, encoding=sys.getfilesystemencoding())


### PR DESCRIPTION
* Fixes unicode issue (Pandas incorrectly writing unicode characters on some OS)
* Processes dataset on `repos/author/repo` relative path